### PR TITLE
Add throwing NotSupportedException for each profiles

### DIFF
--- a/src/Tizen.NET.MaterialComponents/Components/IOptionalComponent.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/IOptionalComponent.cs
@@ -1,0 +1,10 @@
+
+using System.ComponentModel;
+
+namespace Tizen.NET.MaterialComponents
+{
+    public interface IOptionalComponent
+    {
+        TargetProfile SupportedProfiles { get; }
+    }
+}

--- a/src/Tizen.NET.MaterialComponents/Components/MAppBar.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MAppBar.cs
@@ -6,7 +6,7 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public abstract class MAppBar : Background, IColorSchemeComponent
+    public abstract class MAppBar : Background, IColorSchemeComponent, IOptionalComponent
     {
         Color _defaultBackground;
         Color _oldBackground;
@@ -22,6 +22,8 @@ namespace Tizen.NET.MaterialComponents
 
         public MAppBar (EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             AlignmentX = -1;
             WeightX = 1;
             MinimumHeight = DefaultValues.AppBar.Height;
@@ -42,6 +44,8 @@ namespace Tizen.NET.MaterialComponents
 
             MColors.AddColorSchemeComponent(this);
         }
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile;
 
         protected bool OverflowPopupToDown { get; set; }
 

--- a/src/Tizen.NET.MaterialComponents/Components/MBanner.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MBanner.cs
@@ -4,7 +4,7 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MBanner : Layout
+    public class MBanner : Layout, IOptionalComponent
     {
         Button _actionButton;
         Button _cancelButton;
@@ -17,6 +17,8 @@ namespace Tizen.NET.MaterialComponents
 
         public MBanner(EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             AlignmentX = -1;
             AlignmentY = 0;
             WeightX = 1;
@@ -36,6 +38,8 @@ namespace Tizen.NET.MaterialComponents
         public event EventHandler<EventArgs> ActionClicked;
 
         public event EventHandler<EventArgs> Dismissed;
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.TV;
 
         public override string Text
         {

--- a/src/Tizen.NET.MaterialComponents/Components/MCard.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MCard.cs
@@ -5,13 +5,20 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MCard : Box
+    public class MCard : Box, IOptionalComponent
     {
         Layout _layout;
         bool _hasShadow;
         Color _borderColor;
 
+        public MCard(EvasObject parent) : base(parent)
+        {
+            MaterialComponents.VerifyComponentEnabled(this);
+        }
+
         public new IEnumerable<EvasObject> Children => base.Children.ToList<EvasObject>();
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.TV;
 
         public bool HasShadow
         {
@@ -51,10 +58,6 @@ namespace Tizen.NET.MaterialComponents
                     _layout.SetPartColor(Parts.Layout.Border, _borderColor);
                 }
             }
-        }
-
-        public MCard(EvasObject parent) : base(parent)
-        {
         }
 
         protected override IntPtr CreateHandle(EvasObject parent)

--- a/src/Tizen.NET.MaterialComponents/Components/MCheckBox.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MCheckBox.cs
@@ -2,16 +2,19 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MCheckBox : Check, IColorSchemeComponent
+    public class MCheckBox : Check, IColorSchemeComponent, IOptionalComponent
     {
         Color _defaultBackground;
         Color _defaultBackgroundForDisable;
 
         public MCheckBox(EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
             Style = Styles.CheckBox.Style;
             MColors.AddColorSchemeComponent(this);
         }
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.Wearable;
 
         public override Color Color
         {

--- a/src/Tizen.NET.MaterialComponents/Components/MDialog.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MDialog.cs
@@ -2,12 +2,16 @@
 
 namespace Tizen.NET.MaterialComponents
 {
-    public abstract class MDialog : MPopup
+    public abstract class MDialog : MPopup, IOptionalComponent
     {
         public MDialog(EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             AlignmentX = 0.5;
             AlignmentY = 0.5;
         }
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile;
     }
 }

--- a/src/Tizen.NET.MaterialComponents/Components/MFloatingActionButton.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MFloatingActionButton.cs
@@ -3,7 +3,7 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MFloatingActionButton : IColorSchemeComponent
+    public class MFloatingActionButton : IColorSchemeComponent, IOptionalComponent
     {
         Color _defaultBackground;
         Color _defaultBackgroundForDisable;
@@ -14,6 +14,8 @@ namespace Tizen.NET.MaterialComponents
 
         public MFloatingActionButton(MConformant conformant)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             _button = new Button(conformant.FloatingLayout)
             {
                 Style = Styles.Button.FloatingButton,
@@ -29,6 +31,8 @@ namespace Tizen.NET.MaterialComponents
         }
 
         public event EventHandler Clicked;
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.Wearable;
 
         public Color BackgroundColor
         {

--- a/src/Tizen.NET.MaterialComponents/Components/MMenus.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MMenus.cs
@@ -3,15 +3,18 @@ using System.IO;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MMenus : ContextPopup, IColorSchemeComponent
+    public class MMenus : ContextPopup, IColorSchemeComponent, IOptionalComponent
     {
         public MMenus(EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             Style = Styles.Material;
             IsHorizontal = false;
             AutoHide = true;
             MColors.AddColorSchemeComponent(this);
         }
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile;
 
         void IColorSchemeComponent.OnColorSchemeChanged(bool fromConstructor)
         {

--- a/src/Tizen.NET.MaterialComponents/Components/MModalSheets.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MModalSheets.cs
@@ -2,7 +2,7 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MModalSheets : Panel
+    public class MModalSheets : Panel, IOptionalComponent
     {
         Box _scrim;
         double _bottomSheetDefaultRatio = 0.5;
@@ -13,6 +13,8 @@ namespace Tizen.NET.MaterialComponents
 
         public MModalSheets(MConformant conformant, MModalSheetsDirection direction) : base(conformant)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             _scrim = new Box(conformant)
             {
                 BackgroundColor = Color.Transparent,
@@ -33,6 +35,8 @@ namespace Tizen.NET.MaterialComponents
             _scrim.PackEnd(this);
             conformant.SetPartContent(Parts.Layout.Sheets, _scrim);
         }
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.TV;
 
         void UpdateDirection(MModalSheetsDirection direction)
         {

--- a/src/Tizen.NET.MaterialComponents/Components/MNavigationDrawer.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MNavigationDrawer.cs
@@ -3,7 +3,7 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MNavigationDrawer : Box
+    public class MNavigationDrawer : Box, IOptionalComponent
     {
         MNavigationView _navigationView;
         Box _mainContainer;
@@ -16,6 +16,8 @@ namespace Tizen.NET.MaterialComponents
 
         public MNavigationDrawer(EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             Initialize(parent);
             SetLayoutCallback(() =>
             {
@@ -24,6 +26,8 @@ namespace Tizen.NET.MaterialComponents
         }
 
         public event EventHandler Toggled;
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.TV;
 
         public MNavigationView NavigationView
         {

--- a/src/Tizen.NET.MaterialComponents/Components/MNavigationView.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MNavigationView.cs
@@ -5,7 +5,7 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MNavigationView : Background, IColorSchemeComponent
+    public class MNavigationView : Background, IColorSchemeComponent, IOptionalComponent
     {
         Box _box;
         EvasObject _header;
@@ -24,6 +24,8 @@ namespace Tizen.NET.MaterialComponents
 
         public MNavigationView(EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             Initialize(parent);
             _box.SetLayoutCallback(() =>
             {
@@ -33,6 +35,8 @@ namespace Tizen.NET.MaterialComponents
         }
 
         public event EventHandler<GenListItemEventArgs> MenuItemSelected;
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.TV;
 
         public override Color BackgroundColor
         {

--- a/src/Tizen.NET.MaterialComponents/Components/MRadioButton.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MRadioButton.cs
@@ -2,16 +2,20 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MRadioButton : Radio, IColorSchemeComponent
+    public class MRadioButton : Radio, IColorSchemeComponent, IOptionalComponent
     {
         Color _defaultIcon;
         Color _defaultIconForDisable;
 
         public MRadioButton(EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             Style = Styles.RadioButton.Style;
             MColors.AddColorSchemeComponent(this);
         }
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.Wearable;
 
         public override Color Color
         {

--- a/src/Tizen.NET.MaterialComponents/Components/MSnackBars.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MSnackBars.cs
@@ -4,7 +4,7 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MSnackBars : MPopup, IColorSchemeComponent
+    public class MSnackBars : MPopup, IColorSchemeComponent, IOptionalComponent
     {
         Color _defaultBackgroundColor;
         Color _defaultTextColor;
@@ -12,12 +12,16 @@ namespace Tizen.NET.MaterialComponents
 
         public MSnackBars(EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             Style = Styles.Popup.SnackBars;
             Orientation = PopupOrientation.Bottom;
             MColors.AddColorSchemeComponent(this);
         }
 
         public event EventHandler ActionClicked;
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.TV;
 
         public override string Text
         {

--- a/src/Tizen.NET.MaterialComponents/Components/MTabs.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MTabs.cs
@@ -4,7 +4,7 @@ using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
-    public class MTabs : Widget, IColorSchemeComponent
+    public class MTabs : Widget, IColorSchemeComponent, IOptionalComponent
     {
         Color _defaultBackgroundColor;
         Color _defaultTextColor;
@@ -17,8 +17,11 @@ namespace Tizen.NET.MaterialComponents
 
         public MTabs(EvasObject parent) : base(parent)
         {
+            MaterialComponents.VerifyComponentEnabled(this);
+
             Style = Styles.Material;
             _toolbar.SelectionMode = ToolbarSelectionMode.Always;
+
             MColors.AddColorSchemeComponent(this);
         }
 
@@ -39,6 +42,8 @@ namespace Tizen.NET.MaterialComponents
                 _type = value;
             }
         }
+
+        public TargetProfile SupportedProfiles => TargetProfile.Mobile | TargetProfile.TV;
 
         public ToolbarItem SelectedItem => _toolbar.SelectedItem;
 

--- a/src/Tizen.NET.MaterialComponents/Components/MTooltip.cs
+++ b/src/Tizen.NET.MaterialComponents/Components/MTooltip.cs
@@ -7,6 +7,8 @@ namespace Tizen.NET.MaterialComponents
     {
         public static void UseMTooltip(this EvasObject control)
         {
+            MaterialComponents.VerifyServiceEnabled((TargetProfile.Mobile | TargetProfile.Wearable));
+
             if(control == null)
             {
                 throw new ArgumentNullException(nameof(control));
@@ -18,6 +20,8 @@ namespace Tizen.NET.MaterialComponents
 
         public static bool IsUsingMTooltip(this EvasObject control)
         {
+            MaterialComponents.VerifyServiceEnabled((TargetProfile.Mobile | TargetProfile.Wearable));
+
             if (control == null)
             {
                 throw new ArgumentNullException(nameof(control));

--- a/src/Tizen.NET.MaterialComponents/InitializationOptions.cs
+++ b/src/Tizen.NET.MaterialComponents/InitializationOptions.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Tizen.NET.MaterialComponents
+{
+    public class InitializationOptions
+    {
+        public bool ThrowOnValidateComponentErrors { get; set; }
+    }
+}

--- a/src/Tizen.NET.MaterialComponents/MaterialComponents.cs
+++ b/src/Tizen.NET.MaterialComponents/MaterialComponents.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Tizen.NET.MaterialComponents
+{
+    public enum ComponentsOptions
+    {
+        All,
+        Supported
+    }
+
+    public static class MaterialComponents
+    {
+
+        public static bool IsInitialized
+        {
+            get;
+            private set;
+        }
+
+        public static ComponentsOptions ComponentOption
+        {
+            get;
+            private set;
+        }
+
+        public static void Init(string resourcePath, ComponentsOptions option = ComponentsOptions.All)
+        {
+            if (!IsInitialized)
+            {
+                ThemeLoader.Initialize(resourcePath);
+                ComponentOption = option;
+                IsInitialized = true;
+            }           
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void VerifyComponentEnabled(IOptionalComponent component)
+        {
+            if (ComponentOption == ComponentsOptions.Supported)
+            {
+                if (!component.SupportedProfiles.HasFlag(ThemeLoader.Profile))
+                {
+                    var errorMessage = $"{component} is not supported on {ThemeLoader.Profile} profile. "
+                        + $"if you want to check how it works without throwing an exception, please set ComponentsOptions.All when you call MaterialComponents.Init(). ";
+
+                    throw new NotSupportedException(errorMessage);
+                }
+            }
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void VerifyServiceEnabled(TargetProfile supportedProfiles, [CallerMemberName]string caller = "")
+        {
+            if (ComponentOption == ComponentsOptions.Supported)
+            {
+                if (!supportedProfiles.HasFlag(ThemeLoader.Profile))
+                {
+                    var errorMessage = $"{caller} method is not supported on {ThemeLoader.Profile} profile. "
+                        + $"if you want to check how it works without throwing an exception, please set ComponentsOptions.All when you call MaterialComponents.Init(). ";
+
+                    throw new NotSupportedException(errorMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/Tizen.NET.MaterialComponents/TargetProfile.cs
+++ b/src/Tizen.NET.MaterialComponents/TargetProfile.cs
@@ -1,14 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
+﻿
 namespace Tizen.NET.MaterialComponents
 {
     public enum TargetProfile
     {
-        Unsupported,
-        Mobile,
-        TV,
-        Wearable
+        Unsupported = 1,
+        Mobile = 2,
+        TV = 4,
+        Wearable = 8
     }
 }

--- a/src/Tizen.NET.MaterialComponents/TargetProfile.cs
+++ b/src/Tizen.NET.MaterialComponents/TargetProfile.cs
@@ -1,6 +1,9 @@
 ﻿
+using System;
+
 namespace Tizen.NET.MaterialComponents
 {
+    [Flags]
     public enum TargetProfile
     {
         Unsupported = 1,

--- a/src/Tizen.NET.MaterialComponents/ThemeLoader.cs
+++ b/src/Tizen.NET.MaterialComponents/ThemeLoader.cs
@@ -1,9 +1,12 @@
 ﻿using System;
+using System.ComponentModel;
 using System.IO;
 using ElmSharp;
 
 namespace Tizen.NET.MaterialComponents
 {
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    [Obsolete("ThemeLoader is obsolete. Please use MaterialComponents.Init instead of ThemeLoader.Initialize.")]
     public static class ThemeLoader
     {
         static Lazy<TargetProfile> s_profile = new Lazy<TargetProfile>(() =>
@@ -32,16 +35,15 @@ namespace Tizen.NET.MaterialComponents
             private set;
         }
 
-        public static bool IsThemeLoaded
+        public static bool IsInitialized
         {
             get;
             private set;
         }
 
-
         public static void Initialize(string resourcePath)
         {
-            if (!IsThemeLoaded)
+            if (!IsInitialized)
             {
                 string fileName = "elmsharp-theme-material.edj";
                 switch (Profile)
@@ -57,7 +59,7 @@ namespace Tizen.NET.MaterialComponents
                 }
                 Elementary.AddThemeOverlay(Path.Combine(resourcePath, fileName));
                 AppResourcePath = resourcePath;
-                IsThemeLoaded = true;
+                IsInitialized = true;
             }
         }
     }

--- a/src/Tizen.NET.MaterialComponents/ThemeLoader.cs
+++ b/src/Tizen.NET.MaterialComponents/ThemeLoader.cs
@@ -32,15 +32,16 @@ namespace Tizen.NET.MaterialComponents
             private set;
         }
 
-        public static bool IsInitialized
+        public static bool IsThemeLoaded
         {
             get;
             private set;
         }
 
+
         public static void Initialize(string resourcePath)
         {
-            if (!IsInitialized)
+            if (!IsThemeLoaded)
             {
                 string fileName = "elmsharp-theme-material.edj";
                 switch (Profile)
@@ -56,7 +57,7 @@ namespace Tizen.NET.MaterialComponents
                 }
                 Elementary.AddThemeOverlay(Path.Combine(resourcePath, fileName));
                 AppResourcePath = resourcePath;
-                IsInitialized = true;
+                IsThemeLoaded = true;
             }
         }
     }

--- a/test/MaterialGallery/BaseGalleryPage.cs
+++ b/test/MaterialGallery/BaseGalleryPage.cs
@@ -1,4 +1,5 @@
 ﻿using ElmSharp;
+using System;
 using Tizen.NET.MaterialComponents;
 
 namespace MaterialGallery
@@ -15,13 +16,11 @@ namespace MaterialGallery
     {
         public abstract string Name { get; }
 
-        public virtual ProfileType ExceptProfile => ProfileType.None;
-
         public virtual bool RunningOnNewWindow => false;
 
         public virtual void Run(Window window)
         {
-            Conformant comformant = CreateComformant(window);
+            var comformant = CreateComformant(window);
             var content = CreateContent(window);
 
             if (Elementary.GetProfile() != "wearable" && content is Box box)

--- a/test/MaterialGallery/Gallery/BannerPage.cs
+++ b/test/MaterialGallery/Gallery/BannerPage.cs
@@ -158,7 +158,7 @@ namespace MaterialGallery
             {
                 Action = "action",
                 Cancel = "dismiss",
-                Icon = Path.Combine(ThemeLoader.AppResourcePath, "image.png"),
+                Icon = Path.Combine(MaterialComponents.AppResourcePath, "image.png"),
                 Text = "Two line text string with two actions. One to two lines is perferable on mobile and tablet."
             };
 
@@ -170,7 +170,7 @@ namespace MaterialGallery
             banner.ActionClicked += (s, e) =>
             {
                 Console.WriteLine($"MBanner.ActionButton is clicked: [Action] Change Icon");
-                banner.Icon = Path.Combine(ThemeLoader.AppResourcePath, "copy.png");
+                banner.Icon = Path.Combine(MaterialComponents.AppResourcePath, "copy.png");
             };
 
             banner.Show();

--- a/test/MaterialGallery/Gallery/BottomAppBarPage.cs
+++ b/test/MaterialGallery/Gallery/BottomAppBarPage.cs
@@ -9,7 +9,7 @@ namespace MaterialGallery
     {
         public override string Name => "Appbar(Bottom) Gallery";
 
-        public override ProfileType ExceptProfile => ProfileType.Wearable;
+        public override bool RunningOnNewWindow => true;
 
         MConformant _conformant;
 

--- a/test/MaterialGallery/Gallery/BottonNavigationPage.cs
+++ b/test/MaterialGallery/Gallery/BottonNavigationPage.cs
@@ -8,7 +8,7 @@ namespace MaterialGallery
     {
         public override string Name => "BottomNavigation Gallery";
 
-        public override ProfileType ExceptProfile => ProfileType.Wearable;
+        public override bool RunningOnNewWindow => true;
 
         public Color backgroudColor = new Color(200, 200, 100);
 
@@ -20,7 +20,7 @@ namespace MaterialGallery
             MBottomNavigation bn = new MBottomNavigation(parent);
             bn.Show();
             box.PackEnd(bn);
-            var IconPath = Path.Combine(ThemeLoader.AppResourcePath, "icon.png");
+            var IconPath = Path.Combine(MaterialComponents.AppResourcePath, "icon.png");
 
             for (int i = 0; i < 4; i++)
             {

--- a/test/MaterialGallery/Gallery/DialogPage.cs
+++ b/test/MaterialGallery/Gallery/DialogPage.cs
@@ -11,7 +11,7 @@ namespace MaterialGallery
         public AccountData(string mail, string iconPath = null)
         {
             Label = mail;
-            IconPath = Path.Combine(ThemeLoader.AppResourcePath, iconPath);
+            IconPath = Path.Combine(MaterialComponents.AppResourcePath, iconPath);
         }
 
         public string Label;

--- a/test/MaterialGallery/Gallery/NavigationDrawerPageGroup.cs
+++ b/test/MaterialGallery/Gallery/NavigationDrawerPageGroup.cs
@@ -8,7 +8,7 @@ namespace MaterialGallery
     {
         public override string Name => "NavigationDrawerPage GalleryGroup";
 
-        public override ProfileType ExceptProfile => ProfileType.Wearable;
+        public override bool RunningOnNewWindow => true;
 
         public override EvasObject CreateContent(EvasObject parent)
         {

--- a/test/MaterialGallery/Gallery/NavigationViewPage.cs
+++ b/test/MaterialGallery/Gallery/NavigationViewPage.cs
@@ -9,7 +9,7 @@ namespace MaterialGallery
     {
         public override string Name => "NavigationView Gallery";
 
-        public override ProfileType ExceptProfile => ProfileType.Wearable;
+        public override bool RunningOnNewWindow => true;
 
         public override EvasObject CreateContent(EvasObject parent)
         {

--- a/test/MaterialGallery/Gallery/TabsPage.cs
+++ b/test/MaterialGallery/Gallery/TabsPage.cs
@@ -7,8 +7,6 @@ namespace MaterialGallery
     {
         public override string Name => "Tabs Gallery";
 
-        public override ProfileType ExceptProfile => ProfileType.Wearable;
-
         public override bool RunningOnNewWindow => true;
 
         public Color backgroudColor = new Color(200, 200, 100);

--- a/test/MaterialGallery/MaterialGallery.cs
+++ b/test/MaterialGallery/MaterialGallery.cs
@@ -24,7 +24,10 @@ namespace MaterialGallery
         void Initialize()
         {
             ResourceDir = DirectoryInfo.Resource;
-            ThemeLoader.Initialize(ResourceDir);
+            MaterialComponents.Init(ResourceDir, new InitializationOptions
+            {
+                ThrowOnValidateComponentErrors = false
+            });
 
             _mainWindow = new Window("MaterialGallery");
             _mainWindow.Show();
@@ -72,14 +75,10 @@ namespace MaterialGallery
 
             foreach (var page in GetGalleryPage())
             {
-                if(Elementary.GetProfile() == "tv" && page.ExceptProfile == ProfileType.TV)
-                {
-                    continue;
-                }
                 list.Append(defaultClass, page);
             }
 
-            if (ThemeLoader.Profile == TargetProfile.Wearable)
+            if (MaterialComponents.Profile == TargetProfile.Wearable)
             {
                 list.Prepend(defaultClass, null);
                 list.Append(defaultClass, null);

--- a/test/MaterialGallery/MaterialGallery.csproj
+++ b/test/MaterialGallery/MaterialGallery.csproj
@@ -1,18 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Tizen.NET.Sdk/1.0.8">
 
-  <!-- Property Group for .NET Core Project -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>tizen40</TargetFramework>
   </PropertyGroup>
 
   <!-- Include Nuget Package for Tizen Project building -->
-  <ItemGroup>
-    <PackageReference Include="Tizen.NET" Version="4.0.0">
-      <ExcludeAssets>Runtime</ExcludeAssets>
-    </PackageReference>
-    <PackageReference Include="Tizen.NET.Sdk" Version="1.0.1" />
-  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Tizen.NET.MaterialComponents\Tizen.NET.MaterialComponents.csproj" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###
This PR is to add throwing NotSupportedException for each profile based on the following link- https://github.com/TizenAPI/Tizen.NET.MaterialComponents/wiki/Limitation-on-Tizen.NET.MaterialComponents

### Issues Resolved ### 
- #43 

### Platforms Affected ### 
- Tizen

### API Changes ###
- Added
  - class 
    - InitializationOptions
  - method
    -  MaterialComponents.Init(string, InitializationOptions)

- ThemeLoader is obsolete.
  ThemeLoader.Initialize is replaced with MaterialComponents.Init


If a user set `InitializationOptions.ThrowOnValidateComponentErrors = true` , the components which not supported on device profile will throw NotSupportedException when it is created.
```
MaterialComponents.Init(ResourceDir, new InitializationOptions 
{
    ThrowOnValidateComponentErrors = true
});
```